### PR TITLE
Delay up to 60 seconds to reset wifi until SOME device exists

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 echo "Installing wifi reset service to /opt/wifi-reset."
 mkdir -p /opt/wifi-reset
-cp -f wifi-reset.sh /opt/wifi-reset/wifi-reset.sh
+cp -f wifi-reset.rb /opt/wifi-reset/wifi-reset.rb
 echo "Installing systemd service to run at boot."
 cp -f wifi-reset.service /lib/systemd/system/wifi-reset.service
 echo "Enabling systemd service."

--- a/wifi-reset.rb
+++ b/wifi-reset.rb
@@ -1,0 +1,11 @@
+#!/usr/bin/ruby
+
+attempts = 0
+while (devices = `iwconfig 2> /dev/null`.split("\n").collect{|line| line =~ /^(\w+)/ && $1}.compact).empty? && attempts < 60  
+  attempts += 1
+  puts "NO wireless devices found (#{attempts})..."
+  sleep 1
+end
+
+devices.each{|device| `ifdown #{device}`}
+devices.each{|device| `ifup #{device}`}

--- a/wifi-reset.service
+++ b/wifi-reset.service
@@ -4,7 +4,7 @@ Description=Wireless Network Reset
 [Service]
 Type=oneshot
 RemainAfterExit=true
-ExecStart=/bin/bash /opt/wifi-reset/wifi-reset.sh
+ExecStart=/opt/wifi-reset/wifi-reset.rb
 
 [Install]
 WantedBy=multi-user.target

--- a/wifi-reset.sh
+++ b/wifi-reset.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
-# Bring all wifi interfaces down.
+
 # Identify wifi interfaces as rows from standard output of iwconfig (NOT standard
 # error, those are non-wifi interfaces) which start without whitespace.
+
+# Wait ~60 seconds until SOME interface exists; then timeout so as not to repeat indefinitely
+while [ -z $(iwconfig 2> /dev/null | grep -o '^[[:alnum:]]\+') ]; do echo NO wireless interface yet defined; sleep 1; done
+
+# Bring all wifi interfaces down.
 iwconfig 2> /dev/null | grep -o '^[[:alnum:]]\+' | while read x; do ifdown $x; done
+
 # Bring all wifi interfaces up.
 iwconfig 2> /dev/null | grep -o '^[[:alnum:]]\+' | while read x; do ifup $x; done


### PR DESCRIPTION
I hope you find this acceptable. It works for me. Since I only wait for 1 device to exist, I'm not sure what would happen if someone needs multiple WiFi devices, but perhaps that is a corner case...
