### PR TITLE
Killing wpa_supplicant

### DIFF
--- a/wifi-reset.service
+++ b/wifi-reset.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Wireless Network Reset
-After=wpa_supplicant.service
+After=wpa_supplicant.service networking.service
 
 [Service]
 Type=oneshot

--- a/wifi-reset.service
+++ b/wifi-reset.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Wireless Network Reset
+After=wpa_supplicant.service
 
 [Service]
 Type=oneshot

--- a/wifi-reset.sh
+++ b/wifi-reset.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
-# Bring all wifi interfaces down.
-# Identify wifi interfaces as rows from standard output of iwconfig (NOT standard
-# error, those are non-wifi interfaces) which start without whitespace.
-sleep 30
-iwconfig 2> /dev/null | grep -o '^[[:alnum:]]\+' | while read x; do ifdown $x; done
-# Bring all wifi interfaces up.
-sleep 30
-iwconfig 2> /dev/null | grep -o '^[[:alnum:]]\+' | while read x; do ifup $x; done
+
+while $(pkill wpa_supplicant); do
+    sleep 0.1
+done
+
+service networking restart
+


### PR DESCRIPTION
I found that many people have problem with wpa_supplicant.
The solution is: kill wpa_supplicant and restart networking
Changes:
 - wifi-reset.sh: Removed all and added killing wpa_supplicant in the loop: if wpa_supplicant is not started: wait 100 ms, if wpa_supplicant is started: exit from loop and restart networking
- wifi-reset.service: Added "After" property.

It perfectly works on beaglebone black on the latest debian image